### PR TITLE
enable arc and curve support, and saved positions (to help with pausing)

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -689,7 +689,6 @@
  *     XY_SKEW_FACTOR        XZ_SKEW_FACTOR        YZ_SKEW_FACTOR
  */
 //#define SKEW_CORRECTION
-
 #if ENABLED(SKEW_CORRECTION)
   // Input all length measurements here:
   #define XY_DIAG_AC 282.8427124746

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1291,10 +1291,26 @@
 
 // @section extras
 
-//
-// G60/G61 Position Save and Return
-//
-//#define SAVED_POSITIONS 1         // Each saved position slot costs 12 bytes
+/** G60/G61 Position Save and Return
+ */
+#define SAVED_POSITIONS 4         // Each saved position slot costs 12 bytes
+
+/** G2/G3 Arc Support
+ */
+#define ARC_SUPPORT                 // Disable this feature to save ~3226 bytes
+#if ENABLED(ARC_SUPPORT)
+  #define MM_PER_ARC_SEGMENT      1 // (mm) Length (or minimum length) of each arc segment
+  //#define ARC_SEGMENTS_PER_R    1 // Max segment length, MM_PER = Min
+  #define MIN_ARC_SEGMENTS       24 // Minimum number of segments in a complete circle
+  //#define ARC_SEGMENTS_PER_SEC 50 // Use feedrate to choose segment length (with MM_PER_ARC_SEGMENT as the minimum)
+  #define N_ARC_CORRECTION       25 // Number of interpolated segments between corrections
+  #define ARC_P_CIRCLES           // Enable the 'P' parameter to specify complete circles
+  //#define CNC_WORKSPACE_PLANES    // Allow G2/G3 to operate in XY, ZX, or YZ planes
+#endif
+
+/** Support for G5 with XYZE destination and IJPQ offsets. Requires ~2666 bytes.
+ */
+#define BEZIER_CURVE_SUPPORT
 
 /** Direct Stepping
  * Comparable to the method used by Klipper, G6 direct stepping significantly

--- a/README.md
+++ b/README.md
@@ -14,10 +14,15 @@ This repo was forked from official [Marlin on GitHub](https://img.shields.io/git
 ### Features
   - BLTouch
   - Z-homing with probe (disabled Z min endstop)
-  - Auto bed leveling
+  - Auto bed leveling (with debug logging enabled)
   - Corner leveling
+  - G26 Leveling test pattern
+  - PID tuned bed (and hotend)
   - Controller Fan
   - Babystepping
+  - Arc Support ([for OctoPrint Arc Welder](https://github.com/FormerLurker/ArcWelderPlugin))
+  - Bed size set small to avoid clips
+  - Print timer and counter
   
 ### Work-arounds
   - Physical X min endstop is using Z max endstop pins on board because X min endstop pins were buggy (randomly ignored)


### PR DESCRIPTION
### Description

* enable 4 saved positions to help with pause in octoprint
* enable arc support for [ArcWelderPlugin](https://github.com/FormerLurker/ArcWelderPlugin) for OctoPrint

### Benefits

pausing in octoprint & potentially smoother prints

### Configurations

_committed_

### Related Issues

None
